### PR TITLE
feat: Create basic Edge proxy extension

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,109 @@
+// Placeholder for proxy server list
+const PROXY_SERVERS = {
+  "US": { name: "United States", host: "3.225.41.109", port: "80", scheme: "http" }, // Assuming HTTP for simplicity, even if HTTPS is supported by proxy
+  "DE": { name: "Germany", host: "161.35.70.249", port: "8080", scheme: "http" },
+  "GB": { name: "United Kingdom", host: "134.209.29.120", port: "80", scheme: "http" }
+};
+
+let currentProxy = null;
+
+// Function to set the proxy
+function setProxy(countryCode) {
+  if (PROXY_SERVERS[countryCode]) {
+    const config = {
+      mode: "fixed_servers",
+      rules: {
+        singleProxy: {
+          scheme: PROXY_SERVERS[countryCode].scheme,
+          host: PROXY_SERVERS[countryCode].host,
+          port: parseInt(PROXY_SERVERS[countryCode].port, 10)
+        },
+        bypassList: ["<local>"] // Bypass proxy for local addresses
+      }
+    };
+    chrome.proxy.settings.set({ value: config, scope: "regular" }, function() {
+      if (chrome.runtime.lastError) {
+        console.error("Error setting proxy:", chrome.runtime.lastError);
+        currentProxy = null;
+        updatePopupState(false, null);
+        return;
+      }
+      console.log("Proxy set to:", countryCode);
+      currentProxy = countryCode;
+      updatePopupState(true, countryCode);
+    });
+  } else {
+    console.warn("No proxy configuration for country:", countryCode);
+    clearProxy(); // Clear proxy if country code is invalid or not found
+  }
+}
+
+// Function to clear the proxy
+function clearProxy() {
+  chrome.proxy.settings.clear({ scope: "regular" }, function() {
+    if (chrome.runtime.lastError) {
+      console.error("Error clearing proxy:", chrome.runtime.lastError);
+      // Even if clearing fails, we update the state to reflect the intent
+    }
+    console.log("Proxy cleared.");
+    currentProxy = null;
+    updatePopupState(false, null);
+  });
+}
+
+// Listen for messages from the popup
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  console.log("Message received in background:", request);
+  if (request.action === "connect") {
+    if (request.country && PROXY_SERVERS[request.country]) {
+      setProxy(request.country);
+      sendResponse({ success: true, message: "Connecting..." });
+    } else {
+      sendResponse({ success: false, message: "Invalid country selected." });
+    }
+  } else if (request.action === "disconnect") {
+    clearProxy();
+    sendResponse({ success: true, message: "Disconnecting..." });
+  } else if (request.action === "getStatus") {
+    sendResponse({
+      success: true,
+      isConnected: !!currentProxy,
+      country: currentProxy
+    });
+  }
+  return true; // Indicates that the response will be sent asynchronously
+});
+
+// Function to send state update to popup (if open)
+function updatePopupState(isConnected, countryCode) {
+  chrome.runtime.sendMessage({
+    action: "updateState",
+    isConnected: isConnected,
+    country: countryCode
+  }).catch(error => {
+    // Catch error if popup is not open or listening
+    if (error.message !== "Could not establish connection. Receiving end does not exist.") {
+        console.warn("Error sending state update to popup:", error);
+    }
+  });
+}
+
+// Initial state check when the extension starts (e.g., browser startup)
+chrome.proxy.settings.get({ incognito: false }, (details) => {
+  if (details.value.mode === 'fixed_servers' && details.value.rules && details.value.rules.singleProxy) {
+    // Try to infer currentProxy if settings were persisted
+    const currentHost = details.value.rules.singleProxy.host;
+    for (const code in PROXY_SERVERS) {
+      if (PROXY_SERVERS[code].host === currentHost) {
+        currentProxy = code;
+        updatePopupState(true, code);
+        break;
+      }
+    }
+  } else {
+    currentProxy = null;
+    updatePopupState(false, null);
+  }
+});
+
+console.log("Background script loaded.");

--- a/images/icon128.png
+++ b/images/icon128.png
@@ -1,0 +1,1 @@
+placeholder content

--- a/images/icon16.png
+++ b/images/icon16.png
@@ -1,0 +1,1 @@
+placeholder content

--- a/images/icon48.png
+++ b/images/icon48.png
@@ -1,0 +1,1 @@
+placeholder content

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,27 @@
+{
+  "manifest_version": 3,
+  "name": "Simple VPN Extension",
+  "version": "0.1.0",
+  "description": "A simple Edge extension to change your perceived location via proxy.",
+  "permissions": [
+    "proxy",
+    "storage",
+    "activeTab"
+  ],
+  "action": {
+    "default_popup": "popup.html",
+    "default_icon": {
+      "16": "images/icon16.png",
+      "48": "images/icon48.png",
+      "128": "images/icon128.png"
+    }
+  },
+  "background": {
+    "service_worker": "background.js"
+  },
+  "icons": {
+    "16": "images/icon16.png",
+    "48": "images/icon48.png",
+    "128": "images/icon128.png"
+  }
+}

--- a/popup.css
+++ b/popup.css
@@ -1,0 +1,64 @@
+body {
+  font-family: sans-serif;
+  width: 250px;
+  padding: 10px;
+  background-color: #f4f4f4;
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+h1 {
+  font-size: 18px;
+  margin-bottom: 10px;
+  color: #333;
+}
+
+.status-section, .location-section {
+  margin-bottom: 15px;
+  width: 100%;
+}
+
+#status {
+  font-weight: bold;
+}
+
+label {
+  display: block;
+  margin-bottom: 5px;
+  font-size: 14px;
+}
+
+select {
+  width: 100%;
+  padding: 8px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  box-sizing: border-box; /* Ensures padding doesn't affect overall width */
+}
+
+button {
+  background-color: #0078D4;
+  color: white;
+  padding: 10px 15px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  width: 100%;
+}
+
+button:hover {
+  background-color: #005a9e;
+}
+
+button.connected {
+    background-color: #d9534f; /* Red for connected state, implying "Disconnect" */
+}
+
+button.connected:hover {
+    background-color: #c9302c;
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Simple VPN</title>
+  <link rel="stylesheet" type="text/css" href="popup.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Simple VPN</h1>
+    <div class="status-section">
+      Status: <span id="status">Disconnected</span>
+    </div>
+    <div class="location-section">
+      <label for="country-select">Select Location:</label>
+      <select id="country-select">
+        <option value="">--Select Country--</option>
+        </select>
+    </div>
+    <button id="connect-button">Connect</button>
+  </div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,120 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const statusDisplay = document.getElementById('status');
+  const countrySelect = document.getElementById('country-select');
+  const connectButton = document.getElementById('connect-button');
+
+  // Placeholder for proxy server list - this will be populated from background
+  let proxyCountries = {};
+
+  // Function to update UI elements
+  function updateUI(isConnected, countryCode) {
+    if (isConnected && countryCode && proxyCountries[countryCode]) {
+      statusDisplay.textContent = `Connected (${proxyCountries[countryCode].name})`;
+      connectButton.textContent = 'Disconnect';
+      connectButton.classList.add('connected');
+      countrySelect.value = countryCode;
+      countrySelect.disabled = true;
+    } else {
+      statusDisplay.textContent = 'Disconnected';
+      connectButton.textContent = 'Connect';
+      connectButton.classList.remove('connected');
+      countrySelect.disabled = false;
+      if (!countryCode && countrySelect.value) {
+        // Don't reset selection if disconnect failed or was an external clear
+      } else if (!countryCode) {
+         countrySelect.value = "";
+      }
+    }
+  }
+
+  // Populate country select from background script's PROXY_SERVERS
+  // For this, we need to get the list from the background script.
+  // However, direct access isn't available. We'll have background send it,
+  // or popup will request it. For now, let's hardcode it for popup rendering
+  // and assume background.js has the primary list.
+
+  // Simplified list for popup rendering - ideally fetched from background.js
+  const localProxyCountries = {
+    "US": { name: "United States" },
+    "DE": { name: "Germany" },
+    "GB": { name: "United Kingdom" }
+  };
+  proxyCountries = localProxyCountries; // Use this for UI population
+
+  for (const code in proxyCountries) {
+    const option = document.createElement('option');
+    option.value = code;
+    option.textContent = proxyCountries[code].name;
+    countrySelect.appendChild(option);
+  }
+
+
+  // Event listener for the connect button
+  connectButton.addEventListener('click', () => {
+    if (connectButton.classList.contains('connected')) {
+      // Action: Disconnect
+      chrome.runtime.sendMessage({ action: 'disconnect' }, (response) => {
+        if (chrome.runtime.lastError) {
+          console.error("Error sending disconnect message:",chrome.runtime.lastError.message);
+          // Handle error appropriately, maybe update UI to show error
+          statusDisplay.textContent = "Error disconnecting";
+          return;
+        }
+        if (response && response.success) {
+          updateUI(false, null);
+        } else {
+          console.warn("Disconnect request failed:", response?.message);
+          // Optionally update UI to show failed disconnect
+        }
+      });
+    } else {
+      // Action: Connect
+      const selectedCountry = countrySelect.value;
+      if (selectedCountry && proxyCountries[selectedCountry]) {
+        chrome.runtime.sendMessage({ action: 'connect', country: selectedCountry }, (response) => {
+          if (chrome.runtime.lastError) {
+            console.error("Error sending connect message:",chrome.runtime.lastError.message);
+            statusDisplay.textContent = "Error connecting";
+            return;
+          }
+          if (response && response.success) {
+            updateUI(true, selectedCountry);
+          } else {
+            console.warn("Connect request failed:", response?.message);
+            statusDisplay.textContent = response?.message || "Failed to connect";
+            updateUI(false, null); // Reset UI
+          }
+        });
+      } else {
+        statusDisplay.textContent = "Please select a country.";
+      }
+    }
+  });
+
+  // Listen for state updates from the background script
+  chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+    if (request.action === "updateState") {
+      console.log("Popup received state update:", request);
+      // Update proxyCountries if background sends a more definitive list
+      // For now, assume the hardcoded list is sufficient for names
+      updateUI(request.isConnected, request.country);
+    }
+  });
+
+  // Request initial status when popup opens
+  chrome.runtime.sendMessage({ action: 'getStatus' }, (response) => {
+    if (chrome.runtime.lastError) {
+        console.error("Error getting initial status:", chrome.runtime.lastError.message);
+        updateUI(false, null); // Assume disconnected if error
+        return;
+    }
+    if (response && response.success) {
+      // Populate countries if background has them (e.g. if background fetched them dynamically)
+      // For now, popup.js has a hardcoded list for display names.
+      // This part would be more robust if background.js was the single source of truth for country list.
+      updateUI(response.isConnected, response.country);
+    } else {
+      updateUI(false, null); // Assume disconnected
+    }
+  });
+});


### PR DESCRIPTION
Implements a simple Microsoft Edge extension that allows you to select a country (US, DE, GB) and routes browser traffic through a public HTTP proxy for that region.

Key features:
- manifest.json: Defines permissions (proxy, storage) and UI components.
- popup.html/css/js: Provides a simple UI for country selection, connect/disconnect, and status display.
- background.js: Manages proxy settings using the chrome.proxy API and communicates with the popup.
- Includes placeholder icons.

This is a proof-of-concept and uses public proxies, which have limitations in reliability, speed, and security.